### PR TITLE
Add MergeQueue and CI configurations

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,44 @@
+name: Test
+
+on:
+  push:
+    # Run CI (only) on our main branch to show that it is always in a green
+    # state. Don't run it on other branches; if a developer cares about one
+    # of the non-main branches they'll run tests manually or open a PR.
+    branches:
+      - "main"
+  pull_request:
+    # Run CI on pull requests. Passing checks will be required to merge.
+    branches:
+      - "**"
+
+concurrency:
+  # Have at most one of these workflows running per branch, cancelling older
+  # runs that haven't completed yet when they become obsolete.
+  #
+  # When pushing new commits to a PR, each one of those commits triggers a new
+  # workflow run that would normally run to completion, even when subsequent
+  # pushes to the PR make their result obsolete. This consumes resources for no
+  # benefit. We override that default behavior to save resources, cancelling any
+  # older still-running workflows when a new workflow starts
+  #
+  # See documentation about the `github` context variables here:
+  #   https://docs.github.com/en/actions/learn-github-actions/contexts#github-context
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Do not cancel runs on the main branch. On the main branch we want every
+  # commit to be tested.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  readme-test:
+    name: README.md test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: readme_test.sh
+        # Run the readme_test.sh script from the root of the repository.
+        # This script is used to validate the README.md file.
+        run: |
+          ./readme_test.sh

--- a/.mergequeue/config.yml
+++ b/.mergequeue/config.yml
@@ -1,0 +1,32 @@
+version: 1.0.0
+merge_rules:
+  publish_status_check: true
+  labels:
+    trigger: mergequeue-ready
+    skip_line: ""
+    merge_failed: ""
+    skip_delete_branch: ""
+  update_latest: true
+  delete_branch: false
+  use_rebase: true
+  enable_comments: true
+  ci_timeout_mins: 0
+  preconditions:
+    number_of_approvals: 1
+    use_github_mergeability: true
+    conversation_resolution_required: true
+  merge_mode:
+    type: default
+    parallel_mode: null
+  auto_update:
+    enabled: false
+    label: ""
+    max_runs_for_update: 0
+  merge_commit:
+    use_title_and_body: false
+  merge_strategy:
+    name: squash
+    override_labels:
+      squash: ""
+      merge: ""
+      rebase: mergequeue-rebase


### PR DESCRIPTION
Before this change, this repo...
* Didn't allow us to use MergeQueue.
* Didn't run CI checks before submitting a PR.

This change adds the necessary configuration files to enable both of
these features. The MergeQueue configuration is based on the
configuration used in `reboot-dev/resemble`. The CI configuration is to
simply run `readme_test.sh` on every PR.