### PR TITLE
Fix bad README.md instruction for `rsm protoc`

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ TODO(benh,zakhar): change the default output directory from `gen/` to `api/`.
 -->
 
 ```shell
-rsm protoc ./api/greeter/greeter.proto
+rsm protoc ./api/hello_world/v1/greeter.proto
 ```
 
 ## Test


### PR DESCRIPTION
Before this change, the `readme_test.sh` was correct but (ugh) didn't match the actual `README.md`.